### PR TITLE
ci: sync readme to modrinth description (#23)

### DIFF
--- a/.github/workflows/sync_descriptions.yml
+++ b/.github/workflows/sync_descriptions.yml
@@ -1,0 +1,28 @@
+name: Sync project description
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - README.md
+
+jobs:
+  modrinth:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Patch Modrinth body
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          jq -Rs '{body: .}' README.md > body.json
+          curl --fail-with-body -sS \
+            -X PATCH "https://api.modrinth.com/v2/project/1RSY6DQH" \
+            -H "Authorization: $MODRINTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-binary @body.json


### PR DESCRIPTION
Closes #23.

Adds `.github/workflows/sync_descriptions.yml` - PATCHes the Modrinth project body with README.md on workflow_dispatch or push to master that touches README.md.

CurseForge has no public API for description updates so it's not in scope here; updates remain manual.